### PR TITLE
unix cp command isnt available on windows

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,7 @@
   "homepage": "./",
   "dependencies": {
     "@craco/craco": "^3.5.0",
+    "copyfiles": "^2.1.0",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-scripts": "2.1.8"
@@ -15,6 +16,7 @@
     "storybook": "start-storybook -p 9001 -c .storybook",
     "start": "concurrently 'yarn react-start' 'wait-on http://localhost:3000/ && cross-env NODE_ENV=development yarn electron-start'",
     "build": "yarn react-build && cp package.json build/ && yarn electron-build",
+    "build": "yarn react-build && copyfiles package.json build/ && yarn electron-build",
     "electron-start": "electron .",
     "electron-build": "electron-packager ./build --out=dist",
     "react-start": "craco start",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "homepage": "./",
   "dependencies": {
     "@craco/craco": "^3.5.0",
-    "copyfiles": "^2.1.0",
     "react": "^16.8.4",
     "react-dom": "^16.8.4",
     "react-scripts": "2.1.8"
@@ -37,6 +36,7 @@
     "@storybook/react": "^5.0.1",
     "babel-loader": "^8.0.5",
     "concurrently": "^4.1.0",
+    "copyfiles": "^2.1.0",
     "cross-env": "^5.2.0",
     "electron": "^4.0.7",
     "electron-packager": "^13.1.1",


### PR DESCRIPTION
small PR to convert platform-specific cp command in the build script to platform-independent copyfiles command